### PR TITLE
Binary expression

### DIFF
--- a/WorkFlowRuleEngine.Test/WorkFlowRuleTest.Basic.Fields.cs
+++ b/WorkFlowRuleEngine.Test/WorkFlowRuleTest.Basic.Fields.cs
@@ -71,6 +71,9 @@ namespace WorkFlowRuleEngine.Tests
             Assert.AreEqual(rez, "JohnJohn");
         }
 
+        [Test]
+        public void UsingBinarryExpression()
+        { }
         
     }
 }

--- a/WorkFlowRuleEngine.Test/WorkFlowRuleTest.Basic.Fields.cs
+++ b/WorkFlowRuleEngine.Test/WorkFlowRuleTest.Basic.Fields.cs
@@ -78,7 +78,7 @@ namespace WorkFlowRuleEngine.Tests
         [Test]
         public void UsingCompiledFunctionForAssertion()
         {
- 
+            //Create a compiled function having a string inputlike "[Discount] = [Discount]*2"
         }
     }
 }

--- a/WorkFlowRuleEngine.Test/WorkFlowRuleTest.Basic.Fields.cs
+++ b/WorkFlowRuleEngine.Test/WorkFlowRuleTest.Basic.Fields.cs
@@ -74,6 +74,11 @@ namespace WorkFlowRuleEngine.Tests
         [Test]
         public void UsingBinarryExpression()
         { }
-        
+
+        [Test]
+        public void UsingCompiledFunctionForAssertion()
+        {
+ 
+        }
     }
 }

--- a/WorkFlowRuleEngine.Test/WorkFlowRuleTestPredicates.cs
+++ b/WorkFlowRuleEngine.Test/WorkFlowRuleTestPredicates.cs
@@ -54,7 +54,7 @@ namespace WorkFlowRuleEngine.Tests
             Rule<Order> orderRule = new Rule<Order>();
             rez = orderRule.Predicate(
               p => p.Condition("[Discount] == 0")
-                  .WhenFalse("[Discount] = 1 " )
+                  .WhenFalse(it=>it.Discount = 5 )
                   .WhenTrue("[Discount] = 2")
               ).Evaluate(Provider.Order);
 


### PR DESCRIPTION
Check how a binary expression can be used for assignement; E.g. 
[Discount] = [Amount] *0.1 is currently done using reflection (PropertyInfo)

The requst is to investigate if there is the possibility to compile a lambda expression of type (Expression leftExpression = right Expression) 
